### PR TITLE
🎬  GHA のワークフローにデフォルトシェルを設定

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,6 +6,10 @@ on:
       - main
   workflow_dispatch:
 
+defaults:
+  run:
+    shell: bash
+
 permissions:
   contents: read
   id-token: write


### PR DESCRIPTION
デフォルト shell を明示的に bash に指定することで、pipefail オプションが有効化されるため。